### PR TITLE
Remove version constraints from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "lint": "vint --version && vint ."
   },
   "dependencies": {
-    "@prettier/plugin-lua": "0.0.1",
-    "@prettier/plugin-php": "^0.16.3",
-    "@prettier/plugin-ruby": "^0.8.0",
-    "@prettier/plugin-xml": "^0.7.2",
-    "prettier": "^3.0.3",
-    "prettier-plugin-svelte": "^2.3.1"
+    "@prettier/plugin-lua": "*",
+    "@prettier/plugin-php": "*",
+    "@prettier/plugin-ruby": "*",
+    "@prettier/plugin-xml": "*",
+    "prettier": "*",
+    "prettier-plugin-svelte": "*"
   },
   "devDependencies": {
     "colors": "^1.3.2",


### PR DESCRIPTION
Allow npm to install current versions, resolving #349